### PR TITLE
Basic tests for Resource HTTP verbs

### DIFF
--- a/octokit/resources.py
+++ b/octokit/resources.py
@@ -138,7 +138,7 @@ class Resource(object):
   # request_params  – Custom request parameters
   # *args           - Uri template argument
   # **kwargs        – Uri template arguments
-  def post(request_params={}, *args, **kwargs):
+  def post(self, request_params={}, *args, **kwargs):
     return self.fetch_resource('POST', request_params, *args, **kwargs)
 
   # Makes an API request with the curent resource using PUT.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ package = []
 requires = [
   "requests >= 2.8.0",
   "uritemplate >= 0.5",
-  "inflection >= 0.3.1"
+  "inflection >= 0.3.1",
+  "requests-mock >= 0.6.0",
 ]
 
 setup(

--- a/test.py
+++ b/test.py
@@ -5,6 +5,9 @@ import os
 
 import octokit
 
+import requests_mock
+import uritemplate
+
 class OctokitTestCase(unittest.TestCase):
   def setUp(self):
     self.username = os.environ['OCTOKIT_TEST_GITHUB_LOGIN']
@@ -12,11 +15,38 @@ class OctokitTestCase(unittest.TestCase):
     auth = (self.username, self.token)
     self.client = octokit.Client(auth=auth)
 
-  def test_authentication(self):
-    assert self.client.current_user.login == self.username
+  # def test_authentication(self):
+  #   assert self.client.current_user.login == self.username
 
-  def test_true(self):
-    assert True
+  # def test_true(self):
+  #   assert True
+
+class HttpVerbTestCase(unittest.TestCase):
+  def setUp(self):
+    self.client = octokit.Client(api_endpoint='mock://api.com/{param}')
+    self.adapter = requests_mock.Adapter()
+    self.client.session.mount('mock', self.adapter)
+
+  # Basic test to ensure that the HTTP verbs in Resource works as 
+  # intended when a valid body is sent.
+  def test_http_verbs_basic(self):
+    verbs_to_methods = [
+      ('GET', self.client.get),
+      ('POST', self.client.post),
+      ('PUT', self.client.put),
+      ('PATCH', self.client.patch),
+      ('DELETE', self.client.delete),
+      ('HEAD', self.client.head),
+      ('OPTIONS', self.client.options),
+    ]
+
+    for verb, method in verbs_to_methods:
+      url = uritemplate.expand(self.client.url, {'param':'foo'})
+      self.adapter.register_uri(verb, url, text='{"success": true}')
+
+      response = method(param='foo')
+      assert response.success
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
- added self param to Resource.post (it was a mistake that it was missing before)
- commented out test that actually hits GitHub
- added basic test for the HTTP verbs in Resource for the case when the response returned is valid JSON

@octokit/ucsd-octokit-py 
