### PR TITLE
Unit test for exceptions

### DIFF
--- a/octokit/exceptions.py
+++ b/octokit/exceptions.py
@@ -75,7 +75,6 @@ STATUS_ERRORS = {
   502: BadGateway,
   503: ServiceUnavailable,
   599: ServerError
-
 }
 
 def handle_status(status, data=None):
@@ -89,5 +88,5 @@ def handle_status(status, data=None):
         error = STATUS_ERRORS.get(599)
       else:
         error = Error
-    errorException = error() if data is None else error(data)
+    errorException = error(data) if data else error()
     raise errorException

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,28 @@
+import unittest
+
+import requests_mock
+
+import octokit
+
+class TestExceptions(unittest.TestCase):
+    """Tests the exception handling code in octokit/exceptions.py"""
+
+    def setUp(self):
+        self.client = octokit.Client(api_endpoint='mock://api.com/')
+        self.adapter = requests_mock.Adapter()
+        self.client.session.mount('mock', self.adapter)
+
+    def test_exceptions(self):
+        """Test that HTTP response status codes raise the correct errors."""
+        for status_code, exception in octokit.exceptions.STATUS_ERRORS.items():
+            self.adapter.register_uri(
+                'GET',
+                self.client.url,
+                status_code=status_code
+            )
+
+            with self.assertRaises(exception):
+                self.client.get()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Since it seems like we're going to refactor where/how `handle_status` is called (eventually), I wrote tests for exceptions.py. 

It just loops through the status code to exception mapping we defined already, mocks a HTTP response with each, and verifies that the exception that should be raised is raised.

(#11)

/cc @octokit/ucsd-octokit-py 
